### PR TITLE
修复'快速上手'中未生效的高亮标记

### DIFF
--- a/docs/start/fast.md
+++ b/docs/start/fast.md
@@ -80,7 +80,8 @@ OneBot 服务端的 access_token 是什么？ (默认值：空)
 [dependencies]
 ...
 
-[workspace] // [!code focus] // [!code ++]
+    // [!code focus:2]
+[workspace] // [!code ++]
 ```
 
 接着
@@ -101,12 +102,12 @@ cargo new plugins/hi --lib
 
 可以看到创建了新的 `plugins/hi` 目录，这也是推荐的插件开发方法，有目录管理总会是好的。
 
-```
+```shell
 .
-├── plugins // [!code ++]
-│   └── hi // [!code ++]
-│       └── src // [!code ++]
-│           └── lib.rs // [!code ++]
+├── plugins # [!code ++]
+│   └── hi  # [!code ++]
+│       └── src # [!code ++]
+│           └── lib.rs  # [!code ++]
 ├── src
 │   └── main.rs
 │


### PR DESCRIPTION
使用了一些神秘方法，让'快速上手'中未生效的高亮标记正常显示

Before:  
![image](https://github.com/user-attachments/assets/96671b41-ddce-48bb-a350-f74b2f70a506)  

After: 
![image](https://github.com/user-attachments/assets/831ad8c8-5fd6-47b7-b1a5-33f7f5660381)  

具体做了什么：
- 利用 [!code focus] 可以指定行数的特性，使其与 [!code ++] 作用于同一行
- 将文件树变动标记为 `shell`,  "#" 代替 "//" 成为注释符号 