### PR TITLE
feat: add kovi-plugin-acl to plugin list

### DIFF
--- a/docs/public/plugin_list.toml
+++ b/docs/public/plugin_list.toml
@@ -311,3 +311,16 @@ documentation = "https://github.com/yiranxiaohui/kovi-plugin-meme/blob/main/READ
 author_name = "yiranxiaohui"
 author_url = "https://github.com/yiranxiaohui"
 avatar_url = "https://avatars.githubusercontent.com/u/100197557?v=4"
+
+[acl]
+type = "git"
+shop_name = "ACL 访问控制"
+plugin_type = "normal"
+package_name = "kovi-plugin-acl"
+description = "Kovi 的动态访问控制列表插件，支持 QQ 指令与 WebUI 管理，JWT 认证，密码重置，白名单/黑名单模式切换。"
+git_url = "https://github.com/Hogw4rts/kovi-plugin-acl.git"
+repository = "https://github.com/Hogw4rts/kovi-plugin-acl"
+documentation = "https://github.com/Hogw4rts/kovi-plugin-acl"
+author_name = "Southseast"
+author_url = "https://github.com/Hogw4rts"
+avatar_url = "https://avatars.githubusercontent.com/u/74965592?v=4"


### PR DESCRIPTION
## Summary
- Add kovi-plugin-acl entry to plugin_list.toml

## Details
Dynamic access control list plugin for Kovi framework:
- QQ commands: /acl list, show, on/off, mode, add/del, reset
- WebUI management panel with React + shadcn/ui
- JWT authentication with IP rate limiting
- Password reset via QQ verification code
- Persistent ACL storage per plugin (whitelist/blacklist preserved independently across mode switches)
- Embedded web assets via include_dir! (cargo-add ready)
- System tab: runtime info, OneBot version, admin list